### PR TITLE
build: use winpython and fix bugs

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,30 +1,27 @@
-@echo OFF
-set Miniconda_dir=C:\DVC
-set Miniconda_bin=Miniconda3-latest-Windows-x86_64.exe
-set Miniconda_url=https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe 
-set Src_dir=%cd%
+REM @echo OFF
 
-rmdir /Q /S %Miniconda_dir%
-del /Q /S %Miniconda_bin%
+rmdir /Q /S dist
+rmdir /Q /S WinPython
 del /Q /S "dvc-*.exe"
 
-call powershell.exe -Command (new-object System.Net.WebClient).DownloadFile('%Miniconda_url%','%Miniconda_bin%')
+if not exist WinPython-64bit-3.6.1.0Zero.exe (echo Error: Couldn't find WinPython installer. Please go to winpython.github.io, download WinPython-64bit-3.6.1.0Zero.exe and place it in project's root directory && goto:eof)
 
-REM NOTE: This is extremely important, that we use same directory that we will install dvc into.
-REM 	  The reason is that dvc.exe will have hardcoded path to python interpreter and thus we need
-REM 	  to make sure that it is the same everywhere(C:\DVC).
-call .\%Miniconda_bin% /InstallationType=JustMe /RegisterPython=0 /S /D=%Miniconda_dir%
+if not exist "C:\Program Files (x86)\Inno Setup 5\ISCC.exe" (echo Error: Couldn't find Inno Setup compiler. Please go to jrsoftware.org/isinfo.php and install Inno Setup 5 && goto:eof)
 
-copy innosetup\addSymLinkPermissions.ps1 %Miniconda_dir%\
+call .\WinPython-64bit-3.6.1.0Zero.exe /S /D=%cd%\WinPython
 
-pushd %Miniconda_dir%
-call .\python -m pip install -r %Src_dir%\requirements.txt
-popd
+copy innosetup\addSymLinkPermissions.ps1 WinPython\
+mkdir Winpython\bin
+copy innosetup\dvc.bat WinPython\bin
 
-call %Miniconda_dir%\python setup.py sdist
+cd WinPython
+call scripts\python -m pip install -r ..\requirements.txt
+cd ..
 
-pushd %Miniconda_dir%
-call .\python -m pip install %Src_dir%\dist\dvc-0.8.1.tar.gz
-popd
+call WinPython\scripts\python setup.py sdist
+
+cd WinPython
+call scripts\python -m pip install ..\dist\dvc-0.8.2.tar.gz
+cd ..
 
 call "C:\Program Files (x86)\Inno Setup 5\iscc" innosetup\setup.iss

--- a/innosetup/addSymLinkPermissions.ps1
+++ b/innosetup/addSymLinkPermissions.ps1
@@ -60,3 +60,5 @@ SECreateSymbolicLinkPrivilege = $($currentSetting)
         return $true;
     }
 }
+
+addSymLinkPermissions $(Get-WMIObject -class Win32_ComputerSystem | select username).username

--- a/innosetup/dvc.bat
+++ b/innosetup/dvc.bat
@@ -1,0 +1,2 @@
+@echo off
+call "%~dp0..\python-3.6.1.amd64\python" -m dvc %*

--- a/innosetup/setup.iss
+++ b/innosetup/setup.iss
@@ -1,10 +1,10 @@
 #define MyAppName "Data Version Control"
 ; FIXME: Hardcoded version is not nice, but will do for now.
-#define MyAppVersion "0.8.1"
+#define MyAppVersion "0.8.2"
 #define MyAppPublisher "Dmitry Petrov"
 #define MyAppURL "https://dataversioncontrol.com/"
 ;#define MyAppExeName "dvc.exe"
-#define MyAppDir "C:\DVC"
+#define MyAppDir "..\WinPython"
 
 [Setup]
 AppId={{8258CE8A-110E-4E0D-AE60-FEE00B15F041}
@@ -15,17 +15,15 @@ AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
-;DefaultDirName={pf}\{#MyAppName}
+DefaultDirName={pf64}\{#MyAppName}
 DefaultGroupName={#MyAppName}
 AllowNoIcons=yes
 LicenseFile=..\LICENSE
 OutputBaseFilename=dvc-{#MyAppVersion}
-Compression=lzma
+Compression=lzma2/max
 SolidCompression=yes
 OutputDir=..\
 ChangesEnvironment=yes
-DefaultDirName={#MyAppDir}
-DisableDirPage=yes
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -50,7 +48,7 @@ const
 function ModPathDir(): TArrayOfString;
 begin
 	setArrayLength(Result, 1)
-	Result[0] := ExpandConstant('{app}');
+	Result[0] := ExpandConstant('{app}\bin');
 end;
 
 // ----------------------------------------------------------------------------
@@ -223,9 +221,9 @@ var
 	ErrorCode: Integer;
 	SRCdir: String;
 begin
-	SRCdir := ExpandConstant('{app}\Scripts');
+	SRCdir := ExpandConstant('{app}');
 	if isUninstaller() = false then
-		Exec('powershell.exe', '-noexit -executionpolicy bypass -File "' + SRCdir + '\addSymLinkPermissions.ps1"', '', SW_SHOW, ewWaitUntilTerminated, ErrorCode);
+		ShellExec('', 'powershell.exe', '-noninteractive -windowstyle hidden -executionpolicy bypass -File "' + SRCdir + '\addSymLinkPermissions.ps1"', '', SW_HIDE, ewWaitUntilTerminated, ErrorCode);
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);


### PR DESCRIPTION
This will allow us to make our installer ~4 times smaller(120MB ->
30MB). This patch also has fix for PATH bug and installs dvc to whatever
direstory user specified.