### PR TITLE
logger: don't forget to call colorama.init()

### DIFF
--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -3,6 +3,8 @@ import logging
 
 import colorama
 
+colorama.init()
+
 class Logger(object):
     DEFAULT_LEVEL = logging.INFO
 


### PR DESCRIPTION
It is fine to not call it in Linux and MacOs, but in windows it results in colors not working in vanilla cmd  prompt.