### PR TITLE
Build rpm and deb packages using PyInstaller and FPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ build/
 dist/
 
 *.egg-info/
+
+hooks/*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ dist/
 *.egg-info/
 
 hooks/*.pyc
+
+*.rpm
+*.deb

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+BUILD_DIR=build
+INSTALL_DIR=$BUILD_DIR/usr
+BIN_DIR=$INSTALL_DIR/bin
+
+print_error()
+{
+	echo -e "\e[31m$1\e[0m"
+}
+
+trap 'print_error "FAIL"; exit 1' ERR
+
+print_info()
+{
+	echo -e "\e[32m$1\e[0m"
+}
+
+command_exists()
+{
+	command -v $1 > /dev/null 2>&1
+}
+
+fpm_build()
+{
+	print_info "Building $1..."
+	fpm -s dir -f -t $1 -n dvc -v $(python -c "import dvc; from dvc.main import VERSION; print(str(VERSION))") $INSTALL_DIR
+}
+
+cleanup()
+{
+	print_info "Cleaning up..."
+	rm -rf build
+}
+
+install_dependencies()
+{
+	print_info "Installing requirements..."
+	pip install -r requirements.txt
+
+	print_info "Installing fpm..."
+	if command_exists dnf; then
+		sudo dnf install ruby-devel gcc make rpm-build
+	elif command_exists yum; then
+		sudo yum install ruby-devel gcc make rpm-build
+	elif command_exists apt-get; then
+		sudo apt-get install ruby ruby-dev rubygems build-essential
+	else
+		echo "Unable to install fpm dependencies" && exit 1
+	fi
+
+	gem install --no-ri --no-rdoc fpm
+
+	print_info "Installing pyinstaller..."
+	pip install pyinstaller
+}
+
+build_dvc()
+{
+	print_info "Building dvc binary..."
+	pyinstaller --onefile --additional-hooks-dir $(pwd)/hooks dvc/__main__.py --name dvc --distpath $BIN_DIR --specpath $BUILD_DIR
+}
+
+cleanup
+install_dependencies
+build_dvc
+fpm_build rpm
+fpm_build deb
+cleanup
+
+print_info "Successfully built dvc rpm and deb packages"

--- a/hooks/hook-google.cloud.py
+++ b/hooks/hook-google.cloud.py
@@ -1,0 +1,2 @@
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('google-cloud-core')

--- a/hooks/hook-google.cloud.storage.py
+++ b/hooks/hook-google.cloud.storage.py
@@ -1,0 +1,2 @@
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('google-cloud-storage')


### PR DESCRIPTION
This patch-set allows us to build deb and rpm packages for linux with standalone dvc binary in them.
It was made possible by using PyInstaller, troubleshooting it's errors for google modules and introducing custom hooks to resolve them. I also created a pull request for PyInstaller [1], so I hope that one day PyInstaller is going to be able to build dvc without additional hooks.

[1] https://github.com/pyinstaller/pyinstaller/pull/2637 