### PR TITLE
sync: handle exceptions

### DIFF
--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -246,8 +246,14 @@ class DataCloudAWS(DataCloudBase):
             return
 
         Logger.info('Downloading cache file from S3 "{}/{}"'.format(bucket.name, key_name))
-        key.get_contents_to_filename(item.resolved_cache.relative,
+
+        try:
+            key.get_contents_to_filename(item.resolved_cache.relative,
                                      cb=create_cb(item.resolved_cache.relative))
+        except Exception as exc:
+            Logger.error('Failed to download "{}": {}'.format(key_name, exc))
+            return
+
         progress.finish_target(os.path.basename(item.resolved_cache.relative))
         Logger.info('Downloading completed')
 
@@ -269,8 +275,14 @@ class DataCloudAWS(DataCloudBase):
             Logger.debug('Checksum miss-match. Re-uploading is required.')
 
         key = bucket.new_key(aws_key)
-        key.set_contents_from_filename(data_item.resolved_cache.relative,
+
+        try:
+            key.set_contents_from_filename(data_item.resolved_cache.relative,
                                        cb=create_cb(data_item.resolved_cache.relative))
+        except Exception as exc:
+            Logger.error('Failed to upload "{}": {}'.format(data_item.resolved_cache.relative, exc))
+            return
+
         progress.finish_target(os.path.basename(data_item.resolved_cache.relative))
 
     def remove_from_cloud(self, data_item):

--- a/dvc/utils.py
+++ b/dvc/utils.py
@@ -64,5 +64,10 @@ def map_progress(func, targets, n_threads):
     """
     progress.set_n_total(len(targets))
     p = ThreadPool(processes=n_threads)
-    p.map(func, targets)
-    progress.finish()
+
+    try:
+        p.map(func, targets)
+    except Exception as exc:
+        Logger.error('Unexpected exception while processing targets: {}'.format(exc))
+    finally:
+        progress.finish()


### PR DESCRIPTION
I.e. if network is gone for some reason, report that we're
able to sync some targets instead of just throwing exceptions
about broken pipe or something.

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>