### PR TITLE
travis: publish dvc rpm and deb installers on releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,15 @@ script:
   - ./build_package.sh
 after_sucess:
   - CODECLIMATE_REPO_TOKEN=7350efa14a67c3911af96dadaabe811b43eead7b466309b47687499bf5d72287 codeclimate-test-reporter
+deploy:
+  provider: releases
+  api_key:
+    secure: sqVsxsM8meieL/1NwvUzZsdTg2nvklzJfGsxhjv6bjSEenih4RmWGMTSLA6+Fxryu/WF87b/gYi7zgIxGh08dutvV1M/La46Dn6ix6rc/Z68aHGiLyjQy2mTUYGCv/mJfXq9fohZUc/0e+X5WeZsr4TT7k9HTAJl0/MpdjFy18lAZwYnYHATnus3ZKV73Q/vZK/4tX9of8XUNM8T+yZZ0EP/29/K38Q89wuFmqe19YC4kkoiEG5PCYwm/dMFVoGHDoSix4zfwim5erBcN94b2d9whD5TM5+Xrm8YpH/eWRvMeBC/kEIWBh7KnTyR9nSEtpbwkkCVgC5r+YfubaQScnQsVvwj93hPKvCFLwrOVXeo9nnXiGEYB6JnmGievB0dpUxh9+jxJxICAsNp6efrc1kfY6MJ1J1JvREt8ISuJk/9bwmmQF1TA1agzM6tgb421WgS2pyjWcA25gjkrkhFeXcyAuun17hgEkEwIIuI0eBogsjgDPU6i3GEIoAS58MGi/Tl+drvjhsAsLM1nWLg3uHFfsM85k0142s9KzxsSgae/Qn+WXiDWMGCppAIsm6j2DnNpQajKVOxMfkQtVkDaOFHOy4zC40sATDu89TQnK5lojk2x68nsAJ6uocSqz9QLAXa9BVZW1M5xIzkI/X5b9T1tapXFdoVhMM7BMuBIzY=
+  file_glob: true
+  file:
+    - dvc*.rpm
+    - dvc*.deb
+  skip_cleanup: true
+  on:
+    tags: true
+    repo: dataversioncontrol/dvc


### PR DESCRIPTION
Travis is able to automatically build and upload releases
to github, so when we will release next dvc version, travis
will automatically upload deb and rpm packages to github.

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>