### PR TITLE
import: resume download

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -223,6 +223,12 @@ def parse_args(argv=None):
                         type=int,
                         default=cpu_count(),
                         help='Number of jobs to run simultaneously.')
+    import_parser.add_argument('-c',
+                        '--continue',
+                        dest='cont',
+                        action='store_true',
+                        default=False,
+                        help='Resume downloading file from url')
     import_parser.set_defaults(func=CmdImportFile)
 
     # Lock


### PR DESCRIPTION
Download to .part file first and rename at the very end,
so if we lose connection we could resume download.
Note: not all servers support 'Range' header, so this
feature is not going to work everywhere.

This feature is activated by -c/--continue cmdline option.

Fixes #108

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>