### PR TITLE
dvc: move config/cache/state/target to .dvc

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -67,18 +67,6 @@ def parse_args(argv=None):
                         '--data-dir',
                         default='data',
                         help='Data directory.')
-    init_parser.add_argument(
-                        '--cache-dir',
-                        default='.cache',
-                        help='Cache directory.')
-    init_parser.add_argument(
-                        '--state-dir',
-                        default='.state',
-                        help='State directory.')
-    init_parser.add_argument(
-                        '--target-file',
-                        default=Config.TARGET_FILE_DEFAULT,
-                        help='Target file.')
     init_parser.set_defaults(func=CmdInit)
 
     # Run

--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -15,7 +15,7 @@ class CmdConfig(CmdBase):
 
     @property
     def _config_path(self):
-        return os.path.join(self.git.git_dir, Config.CONFIG)
+        return os.path.join(self.git.git_dir, Config.CONFIG_DIR, Config.CONFIG)
 
     def _get_key(self, d, name, add=False):
         for k in d.keys():

--- a/dvc/git_wrapper.py
+++ b/dvc/git_wrapper.py
@@ -24,7 +24,7 @@ class GitWrapperI(object):
 
     @property
     def lock_file(self):
-        return os.path.join(self.git_dir_abs, '.' + Config.CONFIG + '.lock')
+        return os.path.join(self.git_dir_abs, Config.CONFIG_DIR, '.' + Config.CONFIG + '.lock')
 
     @property
     def git_dir_abs(self):

--- a/functest/test-init.sh
+++ b/functest/test-init.sh
@@ -8,8 +8,8 @@ dvc_create_git_repo
 
 dvc init
 
-DIRS="data .cache .state"
-FILES="dvc.conf"
+DIRS="data .dvc/cache .dvc/state"
+FILES=".dvc/config"
 
 dvc_check_dirs $DIRS
 dvc_check_files $FILES

--- a/tests/basic_env.py
+++ b/tests/basic_env.py
@@ -34,8 +34,8 @@ class BasicEnvironment(TestCase):
             os.makedirs(self._test_git_dir)
 
         data_dir = os.path.join(self._test_git_dir, 'data')
-        cache_dir = os.path.join(self._test_git_dir, 'cache')
-        state_dir = os.path.join(self._test_git_dir, 'state')
+        cache_dir = os.path.join(self._test_git_dir, ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR)
+        state_dir = os.path.join(self._test_git_dir, ConfigI.CONFIG_DIR, ConfigI.STATE_DIR)
 
         os.makedirs(data_dir)
         os.makedirs(cache_dir)
@@ -74,7 +74,7 @@ class DirHierarchyEnvironment(BasicEnvironment):
         self._commit = commit
 
         self._git = GitWrapperI(git_dir=self._test_git_dir, commit=self._commit)
-        self._config = ConfigI('data', 'cache', 'state')
+        self._config = ConfigI('data')
         self.path_factory = PathFactory(self._git, self._config)
         self.settings = Settings([], self._git, self._config)
 
@@ -103,12 +103,12 @@ class DirHierarchyEnvironment(BasicEnvironment):
 
     def crate_data_item(self, data_file, cache_file=True, content='random text'):
         file_result = os.path.join('data', data_file)
-        state_result = os.path.join('state', data_file + DataItem.STATE_FILE_SUFFIX)
+        state_result = os.path.join(ConfigI.CONFIG_DIR, ConfigI.STATE_DIR, data_file + DataItem.STATE_FILE_SUFFIX)
 
         self.create_content_file(state_result, 'state content')
 
         if cache_file:
-            cache_result = os.path.join('cache', data_file + DataItem.CACHE_FILE_SEP + self._commit)
+            cache_result = os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, data_file + DataItem.CACHE_FILE_SEP + self._commit)
             self.create_content_file(cache_result, content)
 
             relevant_dir = self.relevant_dir(data_file)
@@ -129,5 +129,5 @@ class DirHierarchyEnvironment(BasicEnvironment):
 
     def create_dirs(self, dir):
         os.mkdir(os.path.join('data', dir))
-        os.mkdir(os.path.join('cache', dir))
-        os.mkdir(os.path.join('state', dir))
+        os.mkdir(os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, dir))
+        os.mkdir(os.path.join(ConfigI.CONFIG_DIR, ConfigI.STATE_DIR, dir))

--- a/tests/test_cmd_gc.py
+++ b/tests/test_cmd_gc.py
@@ -81,11 +81,11 @@ class TestCmdDataRemove(BasicEnvironment):
 
     def create_dirs(self, dir):
         os.mkdir(os.path.join(self._test_git_dir, 'data', dir))
-        os.mkdir(os.path.join(self._test_git_dir, 'cache', dir))
-        os.mkdir(os.path.join(self._test_git_dir, 'state', dir))
+        os.mkdir(os.path.join(self._test_git_dir, ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, dir))
+        os.mkdir(os.path.join(self._test_git_dir, ConfigI.CONFIG_DIR, ConfigI.STATE_DIR, dir))
 
     def cache_file_nums(self, pattern):
-        os.chdir(os.path.join(self._test_git_dir, 'cache'))
+        os.chdir(os.path.join(self._test_git_dir, ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR))
         files = []
         for file in glob.glob(pattern):
             files.append(file)
@@ -96,11 +96,11 @@ class TestCmdDataRemove(BasicEnvironment):
 
         file_result = os.path.join('data', dir, data_file)
 
-        state_result = os.path.join('state', dir, data_file + DataItem.STATE_FILE_SUFFIX)
+        state_result = os.path.join(ConfigI.CONFIG_DIR, ConfigI.STATE_DIR, dir, data_file + DataItem.STATE_FILE_SUFFIX)
         self.create_content_file(state_result, 'state content')
 
         file_prefix = data_file + DataItem.CACHE_FILE_SEP
-        cache_result = os.path.join('cache', dir, file_prefix + self._commit)
+        cache_result = os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, dir, file_prefix + self._commit)
         self.create_content_file(cache_result, content)
         relevant_dir = self.relevant_dir(os.path.join(dir, data_file))
         cache_file = os.path.join(relevant_dir, cache_result)
@@ -117,10 +117,10 @@ class TestCmdDataRemove(BasicEnvironment):
         print('----> {} {} {} {}'.format(dir, data_file, cache_file, file_result))
 
         # Additional cache files
-        self.create_content_file(os.path.join('cache', dir, file_prefix + 'aaaaaaa'))
-        self.create_content_file(os.path.join('cache', dir, file_prefix + '1111111'))
-        self.create_content_file(os.path.join('cache', dir, file_prefix + '5555555'))
-        self.create_content_file(os.path.join('cache', dir, file_prefix + '123abff'))
+        self.create_content_file(os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, dir, file_prefix + 'aaaaaaa'))
+        self.create_content_file(os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, dir, file_prefix + '1111111'))
+        self.create_content_file(os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, dir, file_prefix + '5555555'))
+        self.create_content_file(os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, dir, file_prefix + '123abff'))
         return
 
     @staticmethod

--- a/tests/test_cmd_run.py
+++ b/tests/test_cmd_run.py
@@ -22,13 +22,14 @@ class RunBasicTest(TestCase):
         os.mkdir(self.test_dir)
         os.chdir(self.test_dir)
         os.mkdir('data')
-        os.mkdir('cache')
-        os.mkdir('state')
+        os.mkdir(ConfigI.CONFIG_DIR)
+        os.mkdir(os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR))
+        os.mkdir(os.path.join(ConfigI.CONFIG_DIR, ConfigI.STATE_DIR))
 
         self.init_git_repo()
         self.git = GitWrapper()
 
-        self.config = ConfigI('data', 'cache', 'state')
+        self.config = ConfigI('data')
         self.path_factory = PathFactory(self.git, self.config)
 
         self.settings = Settings('run cmd', self.git, self.config)
@@ -36,7 +37,10 @@ class RunBasicTest(TestCase):
 
     def init_git_repo(self):
         Executor.exec_cmd_only_success(['git', 'init'])
-        self.create_file('.gitignore', 'cache\n.dvc.conf.lock')
+        msg = os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR)
+        msg += '\n'
+        msg += os.path.join(ConfigI.CONFIG_DIR, '.' + ConfigI.CONFIG + '.lock')
+        self.create_file('.gitignore', msg)
         Executor.exec_cmd_only_success(['git', 'add', '.gitignore'])
         Executor.exec_cmd_only_success(['git', 'commit', '-m', '"Init test repo"'])
 
@@ -78,8 +82,8 @@ class RunTwoFilesBase(RunBasicTest):
                                               stdout=self.file_name1,
                                               stderr=self.file_name2)
 
-        self.state_file_name1 = os.path.join('state', 'file1' + DataItem.STATE_FILE_SUFFIX)
-        self.state_file_name2 = os.path.join('state', 'file2' + DataItem.STATE_FILE_SUFFIX)
+        self.state_file_name1 = os.path.join(ConfigI.CONFIG_DIR, ConfigI.STATE_DIR, 'file1' + DataItem.STATE_FILE_SUFFIX)
+        self.state_file_name2 = os.path.join(ConfigI.CONFIG_DIR, ConfigI.STATE_DIR, 'file2' + DataItem.STATE_FILE_SUFFIX)
 
         self.state_file1 = None
         self.state_file2 = None

--- a/tests/test_cmd_target.py
+++ b/tests/test_cmd_target.py
@@ -20,36 +20,36 @@ class TestCmdTarget(BasicEnvironment):
         self._commit = commit
 
         self._git = GitWrapperI(git_dir=self._test_git_dir, commit=self._commit)
-        self._config = ConfigI('data', 'cache', 'state', '.target')
+        self._config = ConfigI('data')
         self.path_factory = PathFactory(self._git, self._config)
         self.settings = Settings(['target'], self._git, self._config)
 
         os.chdir(self._test_git_dir)
 
         os.mkdir(os.path.join('data', 'dir1'))
-        os.mkdir(os.path.join('cache', 'dir1'))
+        os.mkdir(os.path.join('.dvc', 'cache', 'dir1'))
 
-        self.file1_cache = os.path.join('cache', 'dir1', 'file1')
+        self.file1_cache = os.path.join('.dvc', 'cache', 'dir1', 'file1')
         self.file1_data = os.path.join('data', 'dir1', 'file1')
 
         open(self.file1_cache, 'w').write('ddfdff')
         System.symlink(self.file1_cache, self.file1_data)
 
-        self.file2_cache = os.path.join('cache', 'file2')
+        self.file2_cache = os.path.join('.dvc', 'cache', 'file2')
         self.file2_data = os.path.join('data', 'file2')
 
         open(self.file2_cache, 'w').write('ddfdff')
         System.symlink(self.file2_cache, self.file2_data)
 
     def test_initial_default_target(self):
-        self.assertFalse(os.path.exists('.target'))
+        self.assertFalse(os.path.exists('.dvc/target'))
 
     def test_single_file(self):
         self.settings.parse_args('target {}'.format(self.file1_data))
         cmd = CmdTarget(self.settings)
 
         self.assertEqual(cmd.run(), 0)
-        self.assertEqual(open('.target').read(), self.file1_data)
+        self.assertEqual(open(os.path.join('.dvc', 'target')).read(), self.file1_data)
 
     def test_multiple_files(self):
         self.settings.parse_args('target {}'.format(self.file1_data))
@@ -60,39 +60,39 @@ class TestCmdTarget(BasicEnvironment):
         self.settings.parse_args('target {}'.format(self.file2_data))
         cmd = CmdTarget(self.settings)
         self.assertEqual(cmd.run(), 0)
-        self.assertEqual(open('.target').read(), self.file2_data)
+        self.assertEqual(open(os.path.join('.dvc', 'target')).read(), self.file2_data)
 
         # Unset target
         self.settings.parse_args('target --unset')
         cmd = CmdTarget(self.settings)
         self.assertEqual(cmd.run(), 0)
-        self.assertEqual(open('.target').read(), '')
+        self.assertEqual(open(os.path.join('.dvc', 'target')).read(), '')
 
     def test_initial_unset(self):
         self.settings.parse_args('target --unset')
         cmd = CmdTarget(self.settings)
         self.assertEqual(cmd.run(), 1)
-        self.assertFalse(os.path.exists('.target'))
+        self.assertFalse(os.path.exists(os.path.join('.dvc', '.target')))
 
     def test_unset_existing_target(self):
         self.settings.parse_args('target {}'.format(self.file1_data))
         cmd = CmdTarget(self.settings)
         self.assertEqual(cmd.run(), 0)
-        self.assertEqual(open('.target').read(), self.file1_data)
+        self.assertEqual(open(os.path.join('.dvc', 'target')).read(), self.file1_data)
 
         self.settings.parse_args('target --unset')
         cmd = CmdTarget(self.settings)
         self.assertEqual(cmd.run(), 0)
-        self.assertEqual(open('.target').read(), '')
+        self.assertEqual(open(os.path.join('.dvc', 'target')).read(), '')
 
     def test_the_same(self):
         self.settings.parse_args('target {}'.format(self.file1_data))
         cmd = CmdTarget(self.settings)
         self.assertEqual(cmd.run(), 0)
-        self.assertEqual(open('.target').read(), self.file1_data)
+        self.assertEqual(open(os.path.join('.dvc', 'target')).read(), self.file1_data)
 
         self.assertEqual(cmd.run(), 0)
-        self.assertEqual(open('.target').read(), self.file1_data)
+        self.assertEqual(open(os.path.join('.dvc', 'target')).read(), self.file1_data)
 
     def test_args_conflict(self):
         self.settings.parse_args('target {} --unset'.format(self.file1_data))

--- a/tests/test_data_file_obj.py
+++ b/tests/test_data_file_obj.py
@@ -13,7 +13,7 @@ class TestDataFileObjBasic(BasicEnvironment):
         BasicEnvironment.init_environment(self, test_dir=os.path.join(os.path.sep, 'tmp', 'ntx_unit_test'))
 
         git = GitWrapperI(git_dir=self._test_git_dir, commit='ad45ba8')
-        config = ConfigI('data', 'cache', 'state')
+        config = ConfigI('data')
 
         file = os.path.join('data', 'file.txt')
         self._data_path = DataItem(file, git, config)
@@ -24,11 +24,11 @@ class TestDataFileObjBasic(BasicEnvironment):
         self.assertEqual(self._data_path.data.abs, data_file_full_path)
 
     def test_cache_file(self):
-        cache_file_full_path = os.path.join(self._test_git_dir, 'cache', 'file.txt_ad45ba8')
+        cache_file_full_path = os.path.join(self._test_git_dir, ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, 'file.txt_ad45ba8')
         self.assertEqual(self._data_path.cache.abs, cache_file_full_path)
 
     def test_state_file(self):
-        state_file_full_path = os.path.join(self._test_git_dir, 'state', 'file.txt.state')
+        state_file_full_path = os.path.join(self._test_git_dir, ConfigI.CONFIG_DIR, ConfigI.STATE_DIR, 'file.txt.state')
         self.assertEqual(self._data_path.state.abs, state_file_full_path)
 
     def test_data_dvs_short(self):
@@ -41,10 +41,10 @@ class TestDataItemWithGivenCache(BasicEnvironment):
         BasicEnvironment.init_environment(self, test_dir=os.path.join(os.path.sep, 'tmp', 'ntx_unit_test'))
 
         self._git = GitWrapperI(git_dir=self._test_git_dir, commit='ad45ba8')
-        self._config = ConfigI('data', 'cache', 'state')
+        self._config = ConfigI('data')
 
         self._file = os.path.join('data', 'file.txt')
-        self._cache = os.path.join('cache', 'file.txt_abcd')
+        self._cache = os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, 'file.txt_abcd')
 
         self._data_item = DataItem(self._file, self._git, self._config, self._cache)
         pass
@@ -62,10 +62,10 @@ class TestDeepDataItemWithGivenCache(BasicEnvironment):
         BasicEnvironment.init_environment(self, test_dir=os.path.join(os.path.sep, 'tmp', 'ntx_unit_test'))
 
         self._git = GitWrapperI(git_dir=self._test_git_dir, commit='ad45ba8')
-        self._config = ConfigI('data', 'cache', 'state')
+        self._config = ConfigI('data')
 
         self._file = os.path.join('data', 'dir1', 'file.txt')
-        self._cache = os.path.join('cache', 'dir1', 'file.txt_abcd')
+        self._cache = os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, 'dir1', 'file.txt_abcd')
 
         self._data_item = DataItem(self._file, self._git, self._config, self._cache)
         pass
@@ -80,11 +80,11 @@ class TestPathFactory(BasicEnvironment):
         BasicEnvironment.init_environment(self, test_dir=os.path.join(os.path.sep, 'tmp', 'ntx_unit_test'))
 
         git = GitWrapperI(git_dir=self._test_git_dir, commit='ad45ba8')
-        config = ConfigI('data', 'cache', 'state')
+        config = ConfigI('data')
         self.path_factory = PathFactory(git, config)
 
         self.data_file = os.path.join('data', 'file.txt')
-        self.cache_file = os.path.join('cache', 'fsymlinc.txt')
+        self.cache_file = os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, 'fsymlinc.txt')
 
         fd = open(self.cache_file, 'w+')
         fd.write('some text')
@@ -127,7 +127,7 @@ class TestPathFactory(BasicEnvironment):
         self.assertTrue(path.abs.endswith(file))
 
     def test_to_data_path(self):
-        exclude_file = os.path.join('cache', 'file2')
+        exclude_file = os.path.join(ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, 'file2')
         data_path_file1 = os.path.join('data', 'file1')
         data_path_file2 = os.path.join('data', 'file2')
         files = [
@@ -152,7 +152,7 @@ class TestDataPathInDataDir(BasicEnvironment):
 
         git = GitWrapperI(git_dir=self._test_git_dir, commit='eeeff8f')
         self.data_dir = 'da'
-        config = ConfigI(self.data_dir, 'ca', 'st')
+        config = ConfigI(self.data_dir)
         self.path_factory = PathFactory(git, config)
 
         deep_path = os.path.join(self.data_dir, 'dir1', 'd2', 'file.txt')
@@ -164,15 +164,15 @@ class TestDataPathInDataDir(BasicEnvironment):
         self.assertEqual(self.data_path.data.abs, target)
 
     def test_cache_file(self):
-        target = os.path.join(self._test_git_dir, 'ca', 'dir1', 'd2', 'file.txt_eeeff8f')
+        target = os.path.join(self._test_git_dir, ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, 'dir1', 'd2', 'file.txt_eeeff8f')
         self.assertEqual(self.data_path.cache.abs, target)
 
     def test_state_file(self):
-        target = os.path.join(self._test_git_dir, 'st', 'dir1', 'd2', 'file.txt.state')
+        target = os.path.join(self._test_git_dir, ConfigI.CONFIG_DIR, ConfigI.STATE_DIR, 'dir1', 'd2', 'file.txt.state')
         self.assertEqual(self.data_path.state.abs, target)
 
     def test_symlink(self):
-        expected = os.path.join('..', '..', '..', 'ca', 'dir1', 'd2', 'file.txt_eeeff8f')
+        expected = os.path.join('..', '..', '..', ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, 'dir1', 'd2', 'file.txt_eeeff8f')
         self.assertEqual(self.data_path.symlink_file, expected)
 
     def test_data_dir(self):
@@ -190,7 +190,7 @@ class TestDataFileObjLongPath(BasicEnvironment):
                                           curr_dir)
 
         self._git = GitWrapperI(git_dir=self._test_git_dir, commit='123ed8')
-        self._config = ConfigI('data', 'cache', 'state')
+        self._config = ConfigI('data')
         self.path_factory = PathFactory(self._git, self._config)
 
         self.data_path = self.path_factory.data_item(os.path.join('..', '..', 'data', 'file1.txt'))
@@ -201,11 +201,11 @@ class TestDataFileObjLongPath(BasicEnvironment):
         self.assertEqual(self.data_path.data.abs, target)
 
     def test_cache_file(self):
-        target = os.path.join(self._test_git_dir, 'cache', 'file1.txt_123ed8')
+        target = os.path.join(self._test_git_dir, ConfigI.CONFIG_DIR, ConfigI.CACHE_DIR, 'file1.txt_123ed8')
         self.assertEqual(self.data_path.cache.abs, target)
 
     def test_state_file(self):
-        target = os.path.join(self._test_git_dir, 'state', 'file1.txt.state')
+        target = os.path.join(self._test_git_dir, ConfigI.CONFIG_DIR, ConfigI.STATE_DIR, 'file1.txt.state')
         self.assertEqual(self.data_path.state.abs, target)
 
     def test_file_name_only(self):
@@ -234,7 +234,7 @@ class RunOutsideGitRepoTest(BasicEnvironment):
 
     def test_outside_git_dir(self):
         git = GitWrapperI(git_dir=self._test_git_dir, commit='123ed8')
-        config = ConfigI('data', 'cache', 'state')
+        config = ConfigI('data')
         path_factory = PathFactory(git, config)
 
         with self.assertRaises(NotInDataDirError):


### PR DESCRIPTION
This is a more natural way to store dvc-related files and dirs
and follows git-logic much better.

Fixes #200

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>