### PR TITLE
dvc: find dvc root

### DIFF
--- a/dvc/command/common/base.py
+++ b/dvc/command/common/base.py
@@ -1,15 +1,27 @@
+import os
+
 from dvc.project import Project
 
 
 class CmdBase(object):
     def __init__(self, args):
-        self.project = Project('.')
+        self.project = Project(self._find_root())
         self.args = args
 
         if args.quiet and not args.verbose:
             self.project.logger.be_quiet()
         elif not args.quiet and args.verbose:
             self.project.logger.be_verbose()
+
+    def _find_root(self):
+        root = os.getcwd()
+        while not os.path.ismount(root):
+            dvc_dir = os.path.join(root, Project.DVC_DIR)
+            if os.path.isdir(dvc_dir):
+                return root
+            root = os.path.dirname(root)
+        msg = "Not a dvc repository (or any parent up to mount point {})"
+        Logger.error(msg.format(root))
 
     def run_cmd(self):
         with self.project.lock:


### PR DESCRIPTION
For now we were able to work only in root dvc directory.
This patch emulates git behaviour by walking up the tree
to find repository root.

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>