### PR TITLE
dvc: calculate 'effective inode' from getfileinfo() on windows

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -95,7 +95,7 @@ class Dependency(object):
         return os.path.getmtime(self.path)
 
     def inode(self):
-        return os.stat(self.path).st_ino
+        return System.inode(self.path)
 
     def save(self):
         if not os.path.exists(self.path):

--- a/dvc/system.py
+++ b/dvc/system.py
@@ -6,6 +6,7 @@ from builtins import str
 
 if os.name == 'nt':
     import ntfsutils.hardlink as winlink
+    from ntfsutils.fs import *
 
 
 class System(object):
@@ -22,6 +23,29 @@ class System(object):
             return os.link(source, link_name)
 
         return winlink.create(source, link_name)
+
+    @staticmethod
+    def _getfileinfo(path):
+        # FIXME: current implementation from ntfsutils doesn't support dirs,
+        # and until https://github.com/sid0/ntfs/pull/10 is not merged and
+        # pip package not updated, we have to use our own version.
+        hfile = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, None, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, None)
+        if hfile is None:
+            raise WinError()
+        info = BY_HANDLE_FILE_INFORMATION()
+        rv = GetFileInformationByHandle(hfile, info)
+        CloseHandle(hfile)
+        if rv == 0:
+            raise WinError()
+        return info
+
+    @staticmethod
+    def inode(path):
+        if System.is_unix():
+            return os.stat(path).st_ino
+
+        info = System._getfileinfo(path)
+        return hash((info.dwVolumeSerialNumber, info.nFileIndexHigh, info.nFileIndexLow))
 
     @staticmethod
     def samefile(path1, path2):


### PR DESCRIPTION
Fixes #535 

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>