### PR TITLE
dvc: don't change mode of files

### DIFF
--- a/dvc/project.py
+++ b/dvc/project.py
@@ -159,9 +159,7 @@ class Project(object):
                 continue
 
             Logger.info(u'Remove \'{}\''.format(file))
-            os.chmod(file, stat.S_IWRITE)
             os.remove(file)
-            os.chmod(cache[inode], stat.S_IREAD)
 
             dir = os.path.dirname(file)
             if len(dir) != 0 and not os.listdir(dir):
@@ -192,16 +190,12 @@ class Project(object):
 
         return list(cache_set)
 
-    def _remove_cache_file(self, cache):
-        os.chmod(cache, stat.S_IWRITE | stat.S_IREAD)
-        os.unlink(cache)
-
     def gc(self):
         clist = self._used_cache()
         for cache in self.cache.all():
             if cache in clist:
                 continue
-            self._remove_cache_file(cache)
+            os.unlink(cache)
             self.logger.info(u'\'{}\' was removed'.format(self.to_dvc_path(cache)))
 
     def push(self, target=None, jobs=1):

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -75,7 +75,6 @@ class TestAddDirWithExistingCache(TestDvc):
 class TestAddModifiedDir(TestDvc):
     def test(self):
         self.dvc.add(self.DATA_DIR)
-        os.chmod(self.DATA, stat.S_IWRITE)
         os.unlink(self.DATA)
         self.dvc.add(self.DATA_DIR)
 

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -13,10 +13,15 @@ class TestCheckout(TestRepro):
     def setUp(self):
         super(TestCheckout, self).setUp()
 
+        self.dvc.add(self.DATA_DIR)
+
         self.orig = 'orig'
         shutil.copy(self.FOO, self.orig)
-        os.chmod(self.FOO, stat.S_IWRITE)
         os.unlink(self.FOO)
+
+        self.orig_dir = 'orig_dir'
+        shutil.copytree(self.DATA_DIR, self.orig_dir)
+        shutil.rmtree(self.DATA_DIR)
 
     def test(self):
         self.dvc.checkout()
@@ -33,10 +38,8 @@ class TestCheckoutCorruptedCacheFile(TestRepro):
 
         time.sleep(1)
 
-        os.chmod(cache, stat.S_IWRITE)
         with open(cache, 'a') as fd:
             fd.write('1')
-        os.chmod(cache, stat.S_IREAD)
 
         self.dvc.checkout()
 

--- a/tests/test_data_cloud.py
+++ b/tests/test_data_cloud.py
@@ -63,18 +63,13 @@ class TestDataCloudBase(TestDvc):
         self.assertEqual(status_dir, STATUS_OK)
 
         # Modify and check status
-        os.chmod(cache, stat.S_IWRITE)
         with open(cache, 'a') as fd:
             fd.write('addon')
-        os.chmod(cache, 0o777)
         status = self.cloud.status(cache)
         self.assertEqual(status, STATUS_MODIFIED)
 
         # Remove and check status
-        for root, dirs, files in os.walk(self.dvc.cache.cache_dir):
-            for f in files:
-                path = os.path.join(root, f)
-                self.dvc._remove_cache_file(path)
+        shutil.rmtree(self.dvc.cache.cache_dir)
 
         status = self.cloud.status(cache)
         self.assertEqual(status, STATUS_DELETED)
@@ -210,10 +205,7 @@ class TestDataCloudLocalCli(TestDvc):
 
         self.main(['status'])
 
-        for root, dirs, files in os.walk(self.dvc.cache.cache_dir):
-            for f in files:
-                path = os.path.join(root, f)
-                self.dvc._remove_cache_file(path)
+        shutil.rmtree(self.dvc.cache.cache_dir)
 
         self.main(['status'])
 

--- a/tests/test_fsck.py
+++ b/tests/test_fsck.py
@@ -74,7 +74,6 @@ class TestFsck(TestDvc):
         foo_cache_file = os.path.join(self.dvc.cache.cache_dir, md5[0:2], md5[2:])
         self.assertTrue(os.path.exists(foo_cache_file))
 
-        os.chmod(foo_cache_file, 0o777)
         os.remove(foo_cache_file)
         self.assertFalse(os.path.exists(foo_cache_file))
 
@@ -87,7 +86,6 @@ class TestFsck(TestDvc):
         self.dvc.add(self.FOO)
         self.dvc.add(self.BAR)
 
-        os.chmod(self.FOO, 0o777)
         os.remove(self.FOO)
         with open(self.FOO, 'w') as fd:
             fd.write('randome stuff s9dfj')
@@ -101,7 +99,6 @@ class TestFsck(TestDvc):
         self.dvc.add(self.FOO)
         self.dvc.add(self.BAR)
 
-        os.chmod(self.FOO, 0o777)
         os.remove(self.FOO)
         with open(self.FOO, 'w') as fd:
             fd.write('randome stuff 39re2fwecsb nj')
@@ -115,7 +112,6 @@ class TestFsck(TestDvc):
         self.dvc.add(self.FOO)
         self.dvc.add(self.BAR)
 
-        os.chmod(self.FOO, 0o777)
         os.remove(self.FOO)
 
         no_data_file = 'baz'

--- a/tests/test_repro.py
+++ b/tests/test_repro.py
@@ -51,7 +51,6 @@ class TestReproChangedData(TestRepro):
         self.assertEqual(len(stages), 2)
 
     def swap_foo_with_bar(self):
-        os.chmod(self.FOO, stat.S_IWRITE)
         os.unlink(self.FOO)
         shutil.copyfile(self.BAR, self.FOO)
 
@@ -87,7 +86,6 @@ class TestReproPhony(TestReproChangedData):
 
 class TestNonExistingOutput(TestRepro):
     def test(self):
-        os.chmod(self.FOO, stat.S_IWRITE)
         os.unlink(self.FOO)
 
         with self.assertRaises(ReproductionError) as cx:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -28,7 +28,6 @@ class TestState(TestDvc):
         # files that were modified within that delta.
         time.sleep(1)        
 
-        os.chmod(path, stat.S_IWRITE)
         os.unlink(path)
         with open(path, 'w+') as fd:
             fd.write('1')


### PR DESCRIPTION
Since we can now detect cache corruption, we don't need
to force any permissions on our data files.

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>