### PR TITLE
test: call nosetests directly

### DIFF
--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,4 +1,7 @@
-import nose
+import os
+from subprocess import check_call
 
-if __name__ == '__main__':
-    nose.main(argv=['--cover-inclusive', '--cover-erase', '--cover-package=dvc', '--with-coverage'])
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+os.chdir(REPO_ROOT)
+
+check_call('nosetests --cover-inclusive --cover-erase --cover-package=dvc --with-coverage', shell=True)


### PR DESCRIPTION
Previous method of calling nose.main() didn't really work on windows.

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>