### PR TITLE
Proper adding of 'directory/'

### DIFF
--- a/dvc/project.py
+++ b/dvc/project.py
@@ -80,7 +80,7 @@ class Project(object):
         return os.path.relpath(path, self.root_dir)
 
     def add(self, fname):
-        out = os.path.basename(fname)
+        out = os.path.basename(os.path.normpath(fname))
         stage_fname = out + Stage.STAGE_FILE_SUFFIX
         cwd = os.path.dirname(os.path.abspath(fname))
         stage = Stage.loads(project=self,

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -49,6 +49,13 @@ class TestAddDirectory(TestDvc):
         self.create(os.path.join(dname, 'file'), 'file')
         self.dvc.add(dname)
 
+class TestAddDirectoryWithForwardSlash(TestDvc):
+    def test(self):
+        dname = 'directory/'
+        os.mkdir(dname)
+        self.create(os.path.join(dname, 'file'), 'file')
+        stage = self.dvc.add(dname)
+        self.assertEquals(os.path.abspath('directory.dvc'), stage.path)
 
 class TestAddTrackedFile(TestDvc):
     def test(self):


### PR DESCRIPTION
 * test for adding single level directory with forward slash in the end
 * normalizing the path that is passed to the add method

When executing 'dvc add directory/' (the slash in the end is the problem), dvc was adding the directory to the data repo but the dvc file that it was creating was named '.dvc' instead of 'directory.dvc'.