### PR TITLE
run: properly generate automatic name when output is a directory and …

### DIFF
--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -43,6 +43,6 @@ class CmdRun(CmdBase):
     def _stage_file_basename(fname):
         result = os.path.basename(fname)
         if len(result) == 0:
-            result = os.path.dirname(fname)
+            result = os.path.basename(os.path.dirname(fname))
         result += Stage.STAGE_FILE_SUFFIX
         return result


### PR DESCRIPTION
…no -f specified

Fixed #720

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>